### PR TITLE
Add basic benchmarks

### DIFF
--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -7,9 +7,9 @@ use sql_builder::prelude::*;
 #[bench]
 fn insert_string_format(bencher: &mut test::Bencher) {
     bencher.iter(|| {
-			for i in 1..100 {
+            for i in 1..100 {
                 format!("INSERT INTO books (title, price) VALUES ('In Search of Lost Time', {}), ('Don Quixote', 200);", test::black_box(i));
-			}
+            }
     });
 }
 

--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -1,0 +1,46 @@
+#![feature(test)]
+
+extern crate test;
+
+use sql_builder::prelude::*;
+
+#[bench]
+fn insert_string_format(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+			for i in 1..100 {
+        format!("INSERT INTO books (title, price) VALUES ('In Search of Lost Time', {}), ('Don Quixote', 200);", test::black_box(i));
+			}
+    });
+}
+
+#[bench]
+fn insert_string_concat(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        for i in 1..100 {
+            let mut sql =
+                "INSERT INTO books (title, price) VALUES ('In Search of Lost Time', ".to_string();
+
+            sql.push_str(&test::black_box(i).to_string());
+
+            sql.push_str("), ('Don Quixote', 200);");
+        }
+    });
+}
+
+#[bench]
+fn insert_builder(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        for i in 1..100 {
+            SqlBuilder::insert_into("books")
+                .field("title")
+                .field("price")
+                .values(&[
+                    quote("In Search of Lost Time"),
+                    test::black_box(i).to_string(),
+                ])
+                .values(&["'Don Quixote', 200"])
+                .sql()
+                .unwrap();
+        }
+    });
+}

--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -8,7 +8,7 @@ use sql_builder::prelude::*;
 fn insert_string_format(bencher: &mut test::Bencher) {
     bencher.iter(|| {
 			for i in 1..100 {
-        format!("INSERT INTO books (title, price) VALUES ('In Search of Lost Time', {}), ('Don Quixote', 200);", test::black_box(i));
+                format!("INSERT INTO books (title, price) VALUES ('In Search of Lost Time', {}), ('Don Quixote', 200);", test::black_box(i));
 			}
     });
 }

--- a/benches/join_select.rs
+++ b/benches/join_select.rs
@@ -1,0 +1,27 @@
+#![feature(test)]
+
+extern crate test;
+
+use sql_builder::prelude::*;
+
+#[bench]
+fn join_select_string(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        "SELECT books.title, shops.total FROM books JOIN shops ON books.id = shops.book;"
+            .to_string();
+    });
+}
+
+#[bench]
+fn join_select_builder(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        SqlBuilder::select_from("books")
+            .inner()
+            .join("shops")
+            .on("books.id = shops.book")
+            .field("books.title")
+            .field("shops.total")
+            .sql()
+            .unwrap();
+    });
+}

--- a/benches/join_select.rs
+++ b/benches/join_select.rs
@@ -7,7 +7,7 @@ use sql_builder::prelude::*;
 #[bench]
 fn join_select_string(bencher: &mut test::Bencher) {
     bencher.iter(|| {
-        "SELECT books.title, shops.total FROM books JOIN shops ON books.id = shops.book;"
+        "SELECT books.title, shops.total FROM books INNER JOIN shops ON books.id = shops.book;"
             .to_string();
     });
 }

--- a/benches/simple_select.rs
+++ b/benches/simple_select.rs
@@ -1,0 +1,38 @@
+#![feature(test)]
+
+extern crate test;
+
+use sql_builder::prelude::*;
+
+#[bench]
+fn simple_select_string_format(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        for i in 1..100 {
+            format!("SELECT price FROM books WHERE id = {}", test::black_box(i));
+        }
+    });
+}
+
+#[bench]
+fn simple_select_string_concat(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        for i in 1..100 {
+            let mut sql = "SELECT price FROM books WHERE id = ".to_owned();
+            sql.push_str(&test::black_box(i).to_string());
+            sql.push(';');
+        }
+    });
+}
+
+#[bench]
+fn simple_select_builder(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        for i in 1..100 {
+            SqlBuilder::select_from("books")
+                .field("price")
+                .and_where_eq("id", test::black_box(i))
+                .sql()
+                .unwrap();
+        }
+    });
+}

--- a/benches/static_select.rs
+++ b/benches/static_select.rs
@@ -1,0 +1,19 @@
+#![feature(test)]
+
+extern crate test;
+
+use sql_builder::prelude::*;
+
+#[bench]
+fn static_select_string(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        "SELECT * FROM tests;".to_string();
+    });
+}
+
+#[bench]
+fn static_select_builder(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        SqlBuilder::select_from("tests").sql().unwrap();
+    });
+}


### PR DESCRIPTION
Some really basic benches comparing sql-builder vs string concatenation & format!() performance.

I initially made them just for my own curiosity, but I thought that I'd at least offer to open a PR for these since someone else might find it interesting too, even if the results might not be too meaningful or useful.

They don't run on stable rust though since `test` seems to still be experimental, but on nightly `cargo bench` works fine to show the results.

For anyone who but is interested in the results but too lazy to run the benches themselves: on my ryzen1700x machine I got the following results:
```
test insert_builder       ... bench:     118,098 ns/iter (+/- 3,382)
test insert_string_concat ... bench:      13,747 ns/iter (+/- 282)
test insert_string_format ... bench:       5,488 ns/iter (+/- 62)

test join_select_builder ... bench:         856 ns/iter (+/- 23)
test join_select_string  ... bench:          13 ns/iter (+/- 0)

test simple_select_builder       ... bench:      69,097 ns/iter (+/- 14,267)
test simple_select_string_concat ... bench:       9,831 ns/iter (+/- 2,175)
test simple_select_string_format ... bench:       4,732 ns/iter (+/- 81)

test static_select_builder ... bench:         342 ns/iter (+/- 28)
test static_select_string  ... bench:          12 ns/iter (+/- 0)
```