### PR TITLE
Adding compound WHERE statement example

### DIFF
--- a/examples/compound_where.rs
+++ b/examples/compound_where.rs
@@ -1,0 +1,20 @@
+use sql_builder::{quote, where_builder::Where, SqlBuilder};
+
+fn main() {
+    let mut builder = SqlBuilder::select_from("table");
+    builder.and_where_eq("field1", quote(""));
+
+    builder.or_where(
+        Where::new("field2")
+            .eq(quote(""))
+            .and(Where::new("field3").eq(quote("")))
+            .in_brackets(),
+    );
+
+    let sql = builder.sql().unwrap();
+    assert_eq!(
+        &sql,
+        r#"SELECT * FROM table WHERE field1 = '' OR ((field2 = '') AND (field3 = ''));"#
+    );
+    println!("{}", sql);
+}


### PR DESCRIPTION
This adds an example for how to accomplish #12 to the examples dir:

```
$ cargo run --example compound_where -q
SELECT * FROM table WHERE field1 = '' OR ((field2 = '') AND (field3 = ''));
``` 